### PR TITLE
Add forecasting functionality with VAR model and related API endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /assets
 
 COPY ./assets /assets
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000","--timeout-keep-alive", "90", "--reload"]

--- a/assets/controllers/forecast_var_controller.py
+++ b/assets/controllers/forecast_var_controller.py
@@ -1,0 +1,55 @@
+import pandas as pd
+import numpy as np
+import yfinance as yf
+from statsmodels.tsa.api import VAR
+
+def fetch_data(tickers, period="10y"):
+    """Obtém dados históricos dos ativos usando yfinance."""
+    data = yf.download(tickers, period=period)["Adj Close"]
+    if data.empty:
+        raise ValueError("Nenhum dado foi retornado para os tickers fornecidos.")
+    data = data.dropna()  # Remove valores NaN
+    data.index = pd.to_datetime(data.index)  # Garantir que o índice seja datetime
+    if not data.index.inferred_freq:
+        data = data.asfreq('B')  # Define frequência como dias úteis, se não houver
+    data = data.ffill()  # Preenche valores ausentes com forward fill
+    return data
+
+
+
+def calculate_metrics(data):
+    returns = data.pct_change(fill_method=None).dropna()  # Evitar preenchimento automático
+    annualized_return = returns.mean() * 252
+    annualized_volatility = returns.std() * np.sqrt(252)
+    metrics = pd.DataFrame({
+        "Retorno Anualizado (%)": annualized_return * 100,
+        "Volatilidade Anualizada (%)": annualized_volatility * 100
+    })
+    return metrics
+
+def calculate_allocation(metrics):
+    if "Retorno Anualizado (%)" not in metrics.columns or "Volatilidade Anualizada (%)" not in metrics.columns:
+        raise ValueError("Métricas esperadas não encontradas nos dados fornecidos.")
+    sharpe_ratios = metrics["Retorno Anualizado (%)"] / metrics["Volatilidade Anualizada (%)"]
+    weights = sharpe_ratios / sharpe_ratios.sum()
+    allocation = pd.DataFrame({
+        "Ativo": metrics.index,
+        "Peso Sugerido (%)": weights * 100
+    }).reset_index(drop=True)
+    return allocation
+
+def forecast_with_var(data, steps=252):
+    """Realiza previsão usando Modelos Vetoriais Autoregressivos (VAR)."""
+    returns = data.pct_change(fill_method=None).dropna()  # Evitar preenchimento automático
+    model = VAR(returns)
+    results = model.fit()
+    forecast = results.forecast(returns.values[-results.k_ar:], steps)
+    forecast_df = pd.DataFrame(forecast, columns=returns.columns)
+    forecast_mean = forecast_df.mean() * 252
+    forecast_volatility = forecast_df.std() * np.sqrt(252)
+    forecast_metrics = pd.DataFrame({
+        "Retorno Anualizado (%)": forecast_mean * 100,
+        "Volatilidade Anualizada (%)": forecast_volatility * 100
+    })
+    return forecast_metrics
+

--- a/assets/controllers/markowitz_controller.py
+++ b/assets/controllers/markowitz_controller.py
@@ -36,7 +36,7 @@ def get_optimal_allocations(tickers):
     return portfolio, image_base64
 
 def run_simulations(tickers, media_retornos, matriz_cov):
-    N = 100000
+    N = 10000
     retornos_esperados = np.zeros(N)
     volatilidades_esperadas = np.zeros(N)
     tabela_sharpe = np.zeros(N)

--- a/assets/controllers/markowitz_controller.py
+++ b/assets/controllers/markowitz_controller.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+import datetime as dt
+import yfinance as yf
+import numpy as np
+from scipy.optimize import minimize
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+import io
+import base64
+
+def get_optimal_allocations(tickers):
+    data_atual = datetime.now()
+
+    dia = data_atual.day
+    mes = data_atual.month
+    ano = data_atual.year
+
+    inicio = dt.date(2004, 1, 1)
+    final = dt.date(ano, mes, dia)
+
+    df = yf.download(tickers, inicio, final)['Adj Close']
+
+    ret = df.pct_change().apply(lambda x: np.log(1+x)).dropna()
+    media_retornos = ret.mean()
+    matriz_cov = ret.cov()
+
+    retornos_esperados, volatilidades_esperadas, tabela_sharpe, tabela_pesos = run_simulations(tickers, media_retornos, matriz_cov)
+
+    i_sharpe_max = tabela_sharpe.argmax()
+    alocacao_ideal = tabela_pesos[i_sharpe_max]
+
+    portfolio = dict(zip(tickers, alocacao_ideal))
+
+    plot = get_optimal_allocation_plot(tickers, retornos_esperados,  volatilidades_esperadas, tabela_sharpe, i_sharpe_max, media_retornos, matriz_cov)
+    image_base64 = convert_to_base64(plot)
+    return portfolio, image_base64
+
+def run_simulations(tickers, media_retornos, matriz_cov):
+    N = 100000
+    retornos_esperados = np.zeros(N)
+    volatilidades_esperadas = np.zeros(N)
+    tabela_sharpe = np.zeros(N)
+    tabela_pesos = np.zeros((N,len(tickers)))
+
+    for k in range(N):
+        pesos = np.random.random(len(tickers))
+        pesos = pesos/np.sum(pesos)
+        tabela_pesos[k, :] = pesos
+
+        retornos_esperados[k] = np.sum(media_retornos * pesos * 252)
+        volatilidades_esperadas[k] = np.sqrt(np.dot(pesos.T, np.dot(matriz_cov*252, pesos)))
+        tabela_sharpe[k] = retornos_esperados[k]/volatilidades_esperadas[k]
+    
+    return retornos_esperados, volatilidades_esperadas, tabela_sharpe, tabela_pesos
+
+
+
+def get_optimal_allocation_plot(tickers, retornos_esperados,  volatilidades_esperadas, tabela_sharpe, i_sharpe_max, media_retornos, matriz_cov):
+    retornos_esperados_arit = np.exp(retornos_esperados) - 1
+    eixo_y_fronteira_eficiente = np.linspace(retornos_esperados_arit.min(), retornos_esperados_arit.max(), 50)
+
+    peso_inicial = [1/len(tickers)] * len(tickers)
+    limites = tuple([(0,1) for ativo in tickers])
+
+    eixo_x_fronteira_eficiente = []
+
+    def get_retorno(peso_teste):
+        peso_teste = np.array(peso_teste)
+        retorno = np.sum(media_retornos * peso_teste) * 252
+        retorno = np.exp(retorno) - 1
+
+        return retorno
+
+    def check_soma_pesos(peso_teste):
+        return np.sum(peso_teste) -1
+
+    def get_vol(peso_teste):
+        peso_teste = np.array(peso_teste)
+        vol = np.sqrt(np.dot(peso_teste.T, np.dot(matriz_cov*252, peso_teste)))
+
+        return vol
+
+    for retorno_possivel in eixo_y_fronteira_eficiente:
+        restricoes = ({'type': 'eq', 'fun': check_soma_pesos}, {'type': 'eq', 'fun': lambda w: get_retorno(w) - retorno_possivel})
+
+        result = minimize(get_vol, peso_inicial, method='SLSQP', bounds=limites, constraints=restricoes)
+
+        eixo_x_fronteira_eficiente.append(result['fun'])
+    
+    fig, ax = plt.subplots()
+
+    ax.scatter(volatilidades_esperadas, retornos_esperados_arit, c=tabela_sharpe)
+    plt.xlabel("Volatilidade esperada")
+    plt.ylabel("Restorno esperado")
+    ax.xaxis.label.set_color('white')
+    ax.yaxis.label.set_color('white')
+    ax.scatter(volatilidades_esperadas[i_sharpe_max], retornos_esperados_arit[i_sharpe_max], c="red")
+    ax.plot(eixo_x_fronteira_eficiente, eixo_y_fronteira_eficiente)
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1,0))
+    ax.xaxis.set_major_formatter(mtick.PercentFormatter(1,0))
+    ax.tick_params(axis='x', colors='white')
+    ax.tick_params(axis='y', colors='white')
+
+    return plt
+
+def convert_to_base64(plot):
+    buf = io.BytesIO()
+    plot.savefig(buf, format="png")
+    plot.close()  
+
+    buf.seek(0)
+    image_base64 = base64.b64encode(buf.read()).decode('utf-8')
+    buf.close()
+
+    return image_base64

--- a/assets/main.py
+++ b/assets/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from database import Base, engine
 from views.item_view import router as item_router
 from views.markowitz import markowitz
+from views.forecast_var_view import forecast_var
 
 app = FastAPI()
 
@@ -9,6 +10,7 @@ Base.metadata.create_all(bind=engine)
 
 app.include_router(item_router)
 app.include_router(markowitz)
+app.include_router(forecast_var)
 
 @app.get("/")
 def read_root():

--- a/assets/models/asset_request.py
+++ b/assets/models/asset_request.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+from typing import List
+
+class AssetRequest(BaseModel):
+    tickers: List[str]  # Lista de símbolos dos ativos para análise

--- a/assets/views/forecast_var_view.py
+++ b/assets/views/forecast_var_view.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException
+import pandas as pd
+from models.asset_request import AssetRequest
+from controllers.forecast_var_controller import fetch_data, calculate_metrics, calculate_allocation, forecast_with_var
+
+forecast_var  = APIRouter()
+
+@forecast_var.post("/forecast_var/")
+async def forecast_var_root(asset_request: AssetRequest):
+    try:
+        # Obter os dados históricos
+        data = fetch_data(asset_request.tickers)
+
+        # Processar métricas e alocações baseadas em dados históricos
+        metrics = calculate_metrics(data)
+        allocation = calculate_allocation(metrics)
+
+        # Gerar previsões e alocações baseadas no modelo VAR
+        forecast = forecast_with_var(data)
+        forecast_allocation = calculate_allocation(forecast)
+
+
+        return {
+            "historical_metrics": metrics.to_dict(),
+            "historical_allocation": allocation.to_dict(orient="records"),
+            "forecast_metrics": forecast.to_dict(),
+            "forecast_allocation": forecast_allocation.to_dict(orient="records")
+        }
+    except Exception as e:
+        import traceback
+        traceback.print_exc()  # Exibe o rastreamento completo no log do console
+        raise HTTPException(status_code=400, detail=str(e))

--- a/assets/views/markowitz.py
+++ b/assets/views/markowitz.py
@@ -1,7 +1,18 @@
-from fastapi import APIRouter
-
+from fastapi import APIRouter, HTTPException
+from controllers.markowitz_controller import get_optimal_allocations
+from models.asset_request import AssetRequest
 markowitz  = APIRouter()
 
-@markowitz.get("/markowitz/")
-def markowitz_root():
-    return {"message": "markowitz"}
+@markowitz.post("/markowitz/")
+def markowitz_root(asset_request: AssetRequest):
+    try:
+        portfolio, plt_base64 = get_optimal_allocations(asset_request.tickers)
+
+        return {
+            "portifolio": portfolio,
+            "plot_base64": plt_base64
+        }
+    except Exception as e:
+        import traceback
+        traceback.print_exc()  # Exibe o rastreamento completo no log do console
+        raise HTTPException(status_code=400, detail=str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ SQLAlchemy==2.0.36
 starlette==0.41.3
 typing_extensions==4.12.2
 uvicorn==0.32.1
+pandas==2.2.3
+yfinance==0.2.50
+statsmodels==0.14.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,7 @@ uvicorn==0.32.1
 pandas==2.2.3
 yfinance==0.2.50
 statsmodels==0.14.4
+datetime
+numpy
+scipy
+matplotlib


### PR DESCRIPTION
Implementação da rota POST - localhost:8000/forecast_var/

modelo de body para requisição: 
{
    "tickers": ["BRL=X", "PETR4.SA", "VALE3.SA", "WEGE3.SA", "GLD"]
}

